### PR TITLE
Fix bash cmdline for installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a tool that converts `txt`, `docx`, `pptx` and `excel` files to `pdf` fi
 ## Dependencies
 
 ```sh
-  pip install docx2pdf ppt2pdf fpdf Pillow img2pdf pywin32
+  pip install -r requirements.txt
 ```
 
 ## Usage


### PR DESCRIPTION
Currently in the README.md file the bash line indicates to insert the python dependencies one by one. However, there is a requirements.txt file that is not used which installs this. I rewrote the command so that it used the file to install all depedencies needed instead.

As a sidenote, i dont know if pywin32 works everywhere. I have a Linux machine and it doesnt find pywin32 on my machine.